### PR TITLE
feat: enable json compatible logs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -160,6 +160,7 @@ async function startVarnishCli () {
       args: [
         '-t', 'off',
         '-q', 'not VCL_Log:nolog',
+        '-j',
         '-F', '{"@timestamp":"%{%Y-%m-%dT%H:%M:%S%z}t","method":"%m","url":"%U","remote_ip":"%h","x_forwarded_for":"%{X-Forwarded-For}i","cache":"%{Varnish:handling}x","bytes":"%b","duration_usec":"%D","status":"%s","request":"%r","ttfb":"%{Varnish:time_firstbyte}x","referrer":"%{Referrer}i","user_agent":"%{User-agent}i"}'
       ]
     }).start()


### PR DESCRIPTION
Add `-j` argument to make `varnishncsa` write JSON compatible logs. 

Motivation: Logs generated by articles containing umlaut characters in their title don't have proper JSON format due to the encoding of the umlaut characters.

[varnishncsa Docs](https://varnish-cache.org/docs/7.3/reference/varnishncsa.html#:~:text=usage%20and%20exit-,%2Dj,-Make%20format%2Dspecifier)