### PR TITLE
feat: local esi tags setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 > [!IMPORTANT]  
 > Forked from Livingdocs. For full context go there
 
+> [!TIP]
+> For local ESI testing see: local-esi-testing/README.md
+
 A varnish setup with config hot reloading, ready to use in kubernetes and dockerized environments.
 
 It includes:

--- a/config.local-esi-testing.yaml
+++ b/config.local-esi-testing.yaml
@@ -1,0 +1,53 @@
+clusters:
+- name: delivery
+  address: host.docker.internal:9010
+- name: externalScripts
+  address: host.docker.internal:4444
+# not needed for ESI integration local testing
+# - name: redirects
+#   address: host.docker.internal:3000
+
+# LIVINGDOCS DEFAULTS, affect ALL requests from Varnish (ESI included)
+# parameters:
+#   default_ttl: 60
+#   default_grace: 86400 
+hooks:
+  vclRecvEnd: |
+    if (req.url ~ "^/external-scripts/") {
+      set req.url = regsub(req.url, "^/external-scripts", "");
+      set req.backend_hint = externalScripts.backend();
+      return (hash);
+    }
+  vclBackendFetchStart: |
+    if (bereq.backend == externalScripts.backend()) {
+      set bereq.http.Host = "host.docker.internal:4444";
+    }
+  vclBackendResponse: |
+    if (bereq.backend == externalScripts.backend()) {
+        set beresp.ttl = 5s;
+        set beresp.grace = 10s;
+    }
+
+  # other hooks not needed for ESI integration local testing
+  #
+  # vclRecvStart: |
+  #   if (req.restarts == 0) {
+  #       set req.http.Orig-Url = req.url;
+  #       set req.url = "/api/probe-bmg/sao" + regsub(req.url, "/$", "");
+  #       set req.backend_hint = redirects.backend();
+  #       return (hash);
+  #   }
+  # vclDeliverStart: |
+  #   if (req.restarts == 0) {
+  #       if (resp.status == 301) {
+  #           return (deliver);
+  #       } else if (resp.status == 302) {
+  #           return (deliver);
+  #       } else if (resp.status == 410) {
+  #           return (deliver);
+  #       } else {
+  #           set req.url = req.http.Orig-Url;
+  #           set req.backend_hint = delivery.backend();
+  #           return (restart);
+  #       }
+  #   }

--- a/docker-compose.local-esi-testing.yml
+++ b/docker-compose.local-esi-testing.yml
@@ -1,0 +1,9 @@
+version: '3.8'
+services:
+  varnish:
+    image: forwardpublishing/fp-varnish:v1.1.4
+    container_name: fp-varnish-esi-tests
+    volumes:
+      - ./config.local-esi-testing.yaml:/etc/varnish/source/config.yaml:ro
+    ports:
+      - "1111:8080"

--- a/local-esi-testing/README.md
+++ b/local-esi-testing/README.md
@@ -1,0 +1,39 @@
+To locally test the ESI tags integration do the following:
+
+1. Start the mock ESI server 
+
+By default it's set to return the current ISO date - this is useful for testing TTL and grace periods
+```sh
+node local-esi-testing/mock-esi.js
+```
+
+2. Start a Varnish instance configured for testing the ESI tags
+```sh
+docker-compose -f ./docker-compose.local-esi-testing.yml up -d 
+```
+
+3. To see its logs:
+```sh
+# shell into it
+docker exec -it fp-varnish-esi-tests sh
+
+# and run varnishlog, for example
+varnishlog -q 'RespStatus >= 500 or BerespStatus >= 500"'
+```
+ 
+4. In the delivery configure the local.js to point to the mock-esi server
+
+```js
+// conf/environments/local.js
+  externalScripts: {
+    enabled: true,
+    urls: {
+      // separate server for ESI tags - better reflective of non-local environments
+      head: 'http://host.docker.internal:4444/external-scripts/head',
+      bodyTop: 'http://host.docker.internal:4444/external-scripts/body-top',
+      bodyBottom: 'http://host.docker.internal:4444/external-scripts/body-bot',
+    },
+  },
+```
+
+5. Accessing localhost:1111/delivery-pathname should now give you back delivery + ESI content

--- a/local-esi-testing/mock-esi.js
+++ b/local-esi-testing/mock-esi.js
@@ -1,0 +1,23 @@
+const http = require("node:http");
+
+const PORT = 4444;
+
+const MIME_TYPES = {
+  default: "application/octet-stream",
+  html: "text/html; charset=UTF-8",
+  js: "application/javascript",
+};
+
+http
+  .createServer(async (req, res) => {
+    // we serve the same resource regardless of the called url
+    // /external-scripts/head, /external-scripts/body-top or /external-scripts/body-bottom
+
+    res.writeHead(200, { "Content-Type": MIME_TYPES.js });
+    res.write(new Date().toISOString());
+    res.end();
+    console.log(`${req.method} ${req.url} 200`);
+  })
+  .listen(PORT);
+
+console.log(`Mock ESI tags server running at http://localhost:${PORT}/`);


### PR DESCRIPTION
Testing ESI locally was hard, this eases it.

Relevant delivery PR: 
https://github.com/forward-distribution/bmg-delivery-web/pull/892